### PR TITLE
Mac authentication bypass automated tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,10 @@ deploy:
 publish: build build-nginx
 	./scripts/publish.sh
 
-test: stop build-dev run
+setup-tests:
+	${DOCKER_COMPOSE} exec -T server sh /test/whitelist_test_mac.sh
+
+test: stop build-dev run setup-tests
 	$(DOCKER_COMPOSE) exec -T client /test/test_eap.sh
 
-.PHONY: build run build-dev publish serve deploy test check-container-registry-account-id
+.PHONY: build run build-dev publish serve deploy test check-container-registry-account-id setup-tests

--- a/test/eapol_test_mab.conf
+++ b/test/eapol_test_mab.conf
@@ -1,0 +1,10 @@
+network={
+    key_mgmt=IEEE8021X
+    eap=TTLS
+    phase2="auth=PAP"
+    anonymous_identity="anonymous@example.com"
+    identity="user@example.com"
+    password="secretr"
+    ca_cert="/etc/raddb/certs/ca.pem"
+    eapol_flags=0
+}

--- a/test/test_eap.sh
+++ b/test/test_eap.sh
@@ -14,9 +14,16 @@ test_eap_tls_ttls() {
   -N30:s:zzzzzzzzzzz #custom attr Called-Station-Id 
 }
 
+test_mab() {
+  eapol_test -r0 -t3 -c /test/eapol_test_mab.conf -a 10.5.0.5 -s testing \
+  -M 00:11:22:33:44:55 \
+  -N30:s:00-11-22-33-44-55 #custom attr Called-Station-Id 
+}
+
 main() {
   test_eap_tls
   test_eap_tls_ttls
+  test_mab
 }
 
 main

--- a/test/whitelist_test_mac.sh
+++ b/test/whitelist_test_mac.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+  
+echo "00-11-22-33-44-55" >> /etc/raddb/authorised_macs
+echo "        Reply-Message = \"Device with MAC Address %{Calling-Station-Id} authorized for network access\"" >> /etc/raddb/authorised_macs


### PR DESCRIPTION
Implemented the MAC Auth Bypass automated tests for the RADIUS server.

Implemented a step in the Make to setup-tests on the server
- This was done because executing else where requires the server to be restarted for a new MAC address.

