### PR TITLE
Disable OCSP for now

### DIFF
--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -30,7 +30,7 @@
 			}
 
 			ocsp {
-				enable = yes
+				enable = no
 				override_cert_url = yes
 				url = "http://{{OCSP_URL}}"
 			}


### PR DESCRIPTION
This is preventing authentications as the endpoint is not accessible.
Will be re-enabled once we can reach the endpoint.