### PR TITLE
Rename letsencrypt server certificate filename

### DIFF
--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -5,9 +5,9 @@
 		cisco_accounting_username_bug = no
 		max_sessions = 4096
 		tls {
-			certificate_file = ${certdir}/letsencrypt.pem
+			certificate_file = ${certdir}/server.pem
 			private_key_password = whatever
-			private_key_file = ${certdir}/letsencrypt.key
+			private_key_file = ${certdir}/server.key
 			dh_file = ${raddbdir}/dh
 			random_file = /dev/random
 			check_crl = yes


### PR DESCRIPTION
This can simply be referred to as server.pem and server.key.
We do not need to couple the name of the certificate provider to the
file name. This allows flexibility to swap out server certificate
providers seemlessly.