### PR TITLE
Allow enabling or disabling CRL with an environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       OCSP_URL: "127.0.0.1:9999"
       LOCAL_DEVELOPMENT: "true"
       CONTAINER_NAME: "server"
+      ENABLE_CRL: "yes"
     depends_on: 
       - db
     networks:
@@ -43,6 +44,7 @@ services:
       OCSP_URL: "127.0.0.1:9999"
       LOCAL_DEVELOPMENT: "true"
       CONTAINER_NAME: "client"
+      ENABLE_CRL: "yes"
     depends_on: 
       - db
     networks:

--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -10,7 +10,7 @@
 			private_key_file = ${certdir}/server.key
 			dh_file = ${raddbdir}/dh
 			random_file = /dev/random
-			check_crl = yes
+			check_crl = {{ENABLE_CRL}}
 			ca_path = ${certdir}
 			cipher_list = "HIGH"
 			ecdh_curve = "secp384r1"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,6 +8,10 @@ inject_db_credentials() {
   sed -i "s/{{DB_NAME}}/${DB_NAME}/g" /etc/raddb/mods-enabled/sql
 }
 
+configure_crl() {
+  sed -i "s/{{ENABLE_CRL}}/${ENABLE_CRL}/g" /etc/raddb/mods-enabled/eap
+}
+
 fetch_certificates() {
     if [ "$LOCAL_DEVELOPMENT" == "true" ]; then
       cp -pr ./certs/* /etc/raddb/certs/
@@ -60,6 +64,7 @@ echo "Starting FreeRadius"
 main() {
   inject_db_credentials
   inject_ocsp_endpoint
+  configure_crl
   fetch_certificates
   fetch_authorised_macs
   setup_tests


### PR DESCRIPTION
This will always be set to true for automated tests, ENABLE_CRL
environment variable in the task definition will allow setting this on
or off for all the other environments.