### PR TITLE
Slim down Docker image size for Radius servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/admin:ruby-2-7-1-alpine3-12
+FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/alpine:alpine-3-14-0
 
 ENV TZ UTC
 ENV PYTHONUNBUFFERED=1
 
 RUN apk update && apk upgrade && apk --no-cache --update add --virtual \
     build-dependencies gnupg && \
-    apk --no-cache add iptables nmap nmap-scripts tzdata nettle-dev openssl-dev curl tshark \
-    bash vim wpa_supplicant make freeradius freeradius-mysql freeradius-eap \
+    apk --no-cache add tzdata nettle-dev openssl-dev curl \
+    bash wpa_supplicant make freeradius freeradius-mysql freeradius-eap \
     openssl build-base gcc libc-dev \
     mysql mysql-client mysql-dev nginx python3 py3-pip \ 
     && python3 && ln -sf python3 /usr/bin/python \
@@ -17,22 +17,16 @@ RUN apk update && apk upgrade && apk --no-cache --update add --virtual \
     && unzip awscli-bundle.zip \
     && rm awscli-bundle.zip \
     && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws \
-    && rm -r ./awscli-bundle
+    && rm -r ./awscli-bundle \
+    && mkdir -p /tmp/radiusd /etc/raddb && openssl dhparam -out /etc/raddb/dh 1024 \
+    && mkdir -p /etc/raddb/certs \
+    && rm -fr /etc/raddb/sites-enabled/*
 
-RUN mkdir -p /tmp/radiusd /etc/raddb && openssl dhparam -out /etc/raddb/dh 1024
 COPY radius /etc/raddb
-RUN chown root /usr/bin/dumpcap
-
 COPY ./radius/clients.conf /etc/raddb/clients.conf
-
-RUN mkdir -p /etc/raddb/certs
 COPY ./test_certs/ ./certs
-
-RUN rm -fr /etc/raddb/sites-enabled/*
 COPY ./radius/sites-enabled/ /etc/raddb/sites-enabled
 COPY ./scripts /scripts
-
-COPY ./test /test
 
 EXPOSE 1812/udp 1813/udp 18120/udp 2083/tcp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
         SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
     volumes:
       - './volumecerts:/sharedcerts'
+      - './test:/test'
     expose:
       - "1812/udp"
       - "1813/udp"
@@ -43,7 +44,7 @@ services:
       DB_NAME: radius
       OCSP_URL: "127.0.0.1:9999"
       LOCAL_DEVELOPMENT: "true"
-      CONTAINER_NAME: "client"
+      CONTAINER_NAME: "test-client"
       ENABLE_CRL: "yes"
     depends_on: 
       - db

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -27,7 +27,7 @@ fetch_authorised_macs() {
 }
 
 setup_tests() {
-  if [ "$LOCAL_DEVELOPMENT" == "true" ]; then
+  if [ "$CONTAINER_NAME" == "test-client" ]; then
     ./test/setup_tests.sh
   fi
 }


### PR DESCRIPTION
- Use Alpine as base image without Ruby installed
- Don't install wireshark, this can be installed if needed for debugging
- Combine RUN commands to have less layers
- Use docker-compose to copy the required tests over, keeping it out of production