### PR TITLE
Use the .pem file for the server certificate private key

### DIFF
--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -7,7 +7,7 @@
 		tls {
 			certificate_file = ${certdir}/server.pem
 			private_key_password = whatever
-			private_key_file = ${certdir}/server.key
+			private_key_file = ${certdir}/server.pem
 			dh_file = ${raddbdir}/dh
 			random_file = /dev/random
 			check_crl = {{ENABLE_CRL}}


### PR DESCRIPTION
The private key is contained in the pem file, no need to manage this as
a separate file.