### PR TITLE
Fetch authorised clients on boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN apk update && apk upgrade && apk --no-cache --update add --virtual \
     && rm -fr /etc/raddb/sites-enabled/*
 
 COPY radius /etc/raddb
-COPY ./radius/clients.conf /etc/raddb/clients.conf
 COPY ./radius/sites-enabled/ /etc/raddb/sites-enabled
 COPY ./scripts /scripts
 

--- a/radius/test_clients.conf
+++ b/radius/test_clients.conf
@@ -1,8 +1,3 @@
-#!/bin/bash
-
-set -ex
-
-cat > /etc/raddb/clients.conf << EOF 
 client test_client {
     ipaddr = 10.5.0.6
     shortname = test_client
@@ -15,5 +10,3 @@ client radsecproxy {
     secret = radsec
     proto = tcp
 }
-
-EOF

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -13,6 +13,14 @@ fetch_certificates() {
     fi
 }
 
+fetch_authorised_clients() {
+  if [ "$LOCAL_DEVELOPMENT" == "true" ]; then
+    mv /etc/raddb/test_clients.conf /etc/raddb/clients.conf
+  else
+    aws s3 sync s3://${RADIUS_CONFIG_BUCKET_NAME}/clients.conf /etc/raddb/
+  fi
+}
+
 fetch_authorised_macs() {
   if ! [ "$LOCAL_DEVELOPMENT" == "true" ]; then
     aws s3 cp s3://${RADIUS_CONFIG_BUCKET_NAME}/authorised_macs /etc/raddb
@@ -33,7 +41,6 @@ rehash_certificates() {
 setup_tests() {
   /test/scripts/setup_test_mac_address.sh
   /test/scripts/setup_test_crl.sh
-  /test/scripts/setup_authorised_clients.sh
 }
 
 echo "Starting FreeRadius"
@@ -43,6 +50,7 @@ main() {
   configure_crl
   fetch_certificates
   fetch_authorised_macs
+  fetch_authorised_clients
   if [ "$LOCAL_DEVELOPMENT" == "true" ]; then
     setup_tests
   fi


### PR DESCRIPTION
When in test mode, use stub users file, when running in production,
fetch clients.conf from S3