### PR TITLE
Update Policy Engine schema to match admin read replica

### DIFF
--- a/radius/sites-enabled/default
+++ b/radius/sites-enabled/default
@@ -35,6 +35,11 @@ authenticate {
 }
 
 post-auth {
+  update request {
+    Client-Shortname := "%{Client-Shortname}"
+  }
+
+  python3
 }
 
 preacct {

--- a/radius/sites-enabled/radsec
+++ b/radius/sites-enabled/radsec
@@ -36,6 +36,11 @@ server radsec {
     eap
   }
 post-auth {
+  update request {
+    Client-Shortname := "%{Client-Shortname}"
+  }
+
+  python3
 }
 
 }


### PR DESCRIPTION
This creates the joins to pull back responses based on the request
attributes.

Re-activate the policy engine in post-auth for sites-enabled.