### PR TITLE
Suppress error message when waiting for test certs to be generated

### DIFF
--- a/test/scripts/generate_certs.sh
+++ b/test/scripts/generate_certs.sh
@@ -4,7 +4,7 @@ set -e
 
 wait_for_certs() {
     printf "Waiting for cert $1 to be generated"
-    until docker exec ${certgenerator_id} ls /etc/raddb/certs/$1
+    until docker exec ${certgenerator_id} ls /etc/raddb/certs/$1 &> /dev/null
     do
         printf "."
         sleep 1


### PR DESCRIPTION
These error messages makes it seem like something has gone wrong when
it's just waiting.