### PR TITLE
Suppress deprecation warning from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,5 +96,4 @@ networks:
      config:
        - subnet: 10.5.0.0/16
   adminnet:
-    external:
-      name: adminnet
+    name: adminnet


### PR DESCRIPTION
It does not need the external namespace