### PR TITLE
Populate created_at and updated_at fields for site_policies

### DIFF
--- a/test/policy_engine_data/test_matching_policy.sql
+++ b/test/policy_engine_data/test_matching_policy.sql
@@ -9,16 +9,16 @@ SET FOREIGN_KEY_CHECKS = 1;
 
 INSERT INTO `sites` (`id`, `name`, `created_at`, `updated_at`)
 VALUES
-	(1,'Probation Site 1','2021-09-01 15:39:04.000000','2021-09-01 15:42:49.611521');
+	(1,'Probation Site 1',now(),now());
 
 INSERT INTO `clients` (`id`, `tag`, `shared_secret`, `ip_range`, `site_id`, `created_at`, `updated_at`)
 VALUES
-	(1,'test_client','test','10.5.0.6/32',1,'2021-09-01 15:43:21.146108','2021-09-01 15:43:21.146108');
+	(1,'test_client','test','10.5.0.6/32',1,now(),now());
 
 INSERT INTO `policies` (`id`, `name`, `description`, `created_at`, `updated_at`, `fallback`)
 VALUES
-	(1,'Test Matching Policy','Test Matching Policy','2021-09-01 15:44:07.702484','2021-09-01 15:44:07.702484',0),
-	(2,'Fallback','Some fallback policy','2021-09-01 15:49:12.352961','2021-09-01 15:49:12.352961',1);
+	(1,'Test Matching Policy','Test Matching Policy',now(),now(),0),
+	(2,'Fallback','Some fallback policy',now(),now(),1);
 
 INSERT INTO `site_policies` (`policy_id`, `site_id`, `created_at`, `updated_at`)
 VALUES
@@ -27,13 +27,13 @@ VALUES
 
 INSERT INTO `responses` (`id`, `response_attribute`, `value`, `created_at`, `updated_at`, `mac_authentication_bypass_id`, `policy_id`)
 VALUES
-	(1,'Tunnel-Type','VLAN','2021-09-01 15:46:58.354468','2021-09-01 15:48:23.253863',NULL,1),
-	(2,'Tunnel-Medium-Type','IEEE-802','2021-09-01 15:47:58.786005','2021-09-01 15:47:58.786005',NULL,1),
-	(3,'Tunnel-Private-Group-Id','777','2021-09-01 15:48:12.971011','2021-09-01 15:48:12.971011',NULL,1),
-	(4,'Reply-Message','Fallback Policy','2021-09-01 15:49:26.559492','2021-09-01 15:49:26.559492',NULL,2);
+	(1,'Tunnel-Type','VLAN',now(),now(),NULL,1),
+	(2,'Tunnel-Medium-Type','IEEE-802',now(),now(),NULL,1),
+	(3,'Tunnel-Private-Group-Id','777',now(),now(),NULL,1),
+	(4,'Reply-Message','Fallback Policy',now(),now(),NULL,2);
 
 INSERT INTO `rules` (`id`, `operator`, `value`, `policy_id`, `request_attribute`, `created_at`, `updated_at`)
 VALUES
-	(1,'equals','user@example.org',1,'User-Name','2021-09-01 15:44:24.523461','2021-09-01 15:44:24.523461'),
-	(2,'equals','127.0.0.1',1,'NAS-IP-Address','2021-09-01 15:44:42.275498','2021-09-01 15:44:42.275498'),
-	(5,'equals','Wireless-802.11',1,'NAS-Port-Type','2021-09-01 15:45:41.656111','2021-09-01 15:45:41.656111');
+	(1,'equals','user@example.org',1,'User-Name',now(),now()),
+	(2,'equals','127.0.0.1',1,'NAS-IP-Address',now(),now()),
+	(5,'equals','Wireless-802.11',1,'NAS-Port-Type',now(),now());

--- a/test/policy_engine_data/test_matching_policy.sql
+++ b/test/policy_engine_data/test_matching_policy.sql
@@ -22,8 +22,8 @@ VALUES
 
 INSERT INTO `site_policies` (`policy_id`, `site_id`, `created_at`, `updated_at`)
 VALUES
-	(1,1,'2021-09-01 15:44:07.702484','2021-09-01 15:44:07.702484'),
-	(2,1,'2021-09-01 15:49:12.352961','2021-09-01 15:49:12.352961');
+	(1,1, now(), now()),
+	(2,1, now(), now());
 
 INSERT INTO `responses` (`id`, `response_attribute`, `value`, `created_at`, `updated_at`, `mac_authentication_bypass_id`, `policy_id`)
 VALUES

--- a/test/policy_engine_data/test_matching_policy.sql
+++ b/test/policy_engine_data/test_matching_policy.sql
@@ -20,10 +20,10 @@ VALUES
 	(1,'Test Matching Policy','Test Matching Policy','2021-09-01 15:44:07.702484','2021-09-01 15:44:07.702484',0),
 	(2,'Fallback','Some fallback policy','2021-09-01 15:49:12.352961','2021-09-01 15:49:12.352961',1);
 
-INSERT INTO `site_policies` (`policy_id`, `site_id`)
+INSERT INTO `site_policies` (`policy_id`, `site_id`, `created_at`, `updated_at`)
 VALUES
-	(1,1),
-	(2,1);
+	(1,1,'2021-09-01 15:44:07.702484','2021-09-01 15:44:07.702484'),
+	(2,1,'2021-09-01 15:49:12.352961','2021-09-01 15:49:12.352961');
 
 INSERT INTO `responses` (`id`, `response_attribute`, `value`, `created_at`, `updated_at`, `mac_authentication_bypass_id`, `policy_id`)
 VALUES


### PR DESCRIPTION
Oddly the pipeline started failing after replacing table
![image](https://user-images.githubusercontent.com/22743709/132658719-93219085-2d02-461f-bb7b-6f42f416cbfc.png)
