### PR TITLE
Downgrade Alpine version to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/alpine:alpine-3-14-0
+FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/network-access-control-server:alpine-3-12
 
 ENV TZ UTC
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
This used to be on Alpine version 3.14, which breaks radsec.
Revert to Alpine 3.12 as a temporary fix until the OS can be rolled
forward. Pinning individual openssl dependencies will create a lot of
maintenance overhead and make it difficult to roll forward when a new
Alpine version is released.