### PR TITLE
Restore NGINX sidecar container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build: check-container-registry-account-id
 	docker build -t radius ./ --build-arg SHARED_SERVICES_ACCOUNT_ID
 
 build-nginx:
-	docker build -t nginx ./test/nginx --build-arg SHARED_SERVICES_ACCOUNT_ID
+	docker build -t nginx ./nginx --build-arg SHARED_SERVICES_ACCOUNT_ID
 
 deploy: 
 	./scripts/deploy.sh

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+ARG SHARED_SERVICES_ACCOUNT_ID
+FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/nginx:nginx-1-19-5-alpine
+
+EXPOSE 8000
+CMD ["/bin/sh", "-c", "sed -i 's/listen  .*/listen 8000;/g' /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"]


### PR DESCRIPTION
This is required for health checks on the load balancers, don't move
this into the integration test repo.