### PR TITLE
Ensure only one fallback response

### DIFF
--- a/radius/mods-config/python3/policyengine.py
+++ b/radius/mods-config/python3/policyengine.py
@@ -71,7 +71,7 @@ def main_policy_responses(cursor, policy_id):
     return group_responses(responses_results)
 
 def fallback_policy_responses(cursor, _site):
-    fallback_sql = "SELECT `response_attribute`, `value` FROM `responses` " \
+    fallback_sql = "SELECT DISTINCT(`response_attribute`), `value` FROM `responses` " \
             "INNER JOIN `policies` ON `policies`.`id` = `responses`.`policy_id` "  \
             "INNER JOIN site_policies sp ON sp.policy_id = policies.id " \
             "INNER JOIN sites s ON s.id = sp.site_id " \


### PR DESCRIPTION
due to the joins, it is possible to get multiple fallback responses.
Prevent this with a distinct clause.