### PR TITLE
Don't run the policy engine on Post-Auth-Type REJECT

### DIFF
--- a/radius/sites-enabled/default
+++ b/radius/sites-enabled/default
@@ -40,14 +40,6 @@ post-auth {
   }
 
   python3
-
-  Post-Auth-Type REJECT {
-    update request {
-      Client-Shortname := "%{Client-Shortname}"
-    }
-
-    python3
-  }
 }
 
 preacct {

--- a/radius/sites-enabled/radsec
+++ b/radius/sites-enabled/radsec
@@ -43,14 +43,6 @@ post-auth {
   }
 
   python3
-
-  Post-Auth-Type REJECT {
-    update request {
-      Client-Shortname := "%{Client-Shortname}"
-    }
-
-    python3
-  }
 }
 
 }


### PR DESCRIPTION
We will only execute the policy engine when authentication has been
successful. Modifying a REJECT to an ACCEPT is not something that needs
to be supported right now.