### PR TITLE
Reference environment variables directly

### DIFF
--- a/radius/mods-config/python3/policyengine.py
+++ b/radius/mods-config/python3/policyengine.py
@@ -1,21 +1,22 @@
 #! /usr/bin/env python3
 
+import os
 import radiusd
 from pymysql import connect, cursors
 from itertools import groupby
 
 def post_auth(p):
-    connection = connect(host='{{DB_HOST}}',
-                             user='{{DB_USER}}',
-                             password='{{DB_PASS}}',
-                             database='{{DB_NAME}}',
+    connection = connect(host=os.environ.get('DB_HOST'),
+                             user=os.environ.get('DB_USER'),
+                             password=os.environ.get('DB_PASS'),
+                             database=os.environ.get('DB_NAME'),
                              cursorclass=cursors.DictCursor)
 
     with connection.cursor() as cursor:
         payload_dict = dict(p)
         if payload_dict.get('EAP-Type') != "TLS":
             return
-        
+
         print(payload_dict)
         policy_id = 0
         grouped_rules_by_policy(cursor, payload_dict['Client-Shortname'])

--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -6,11 +6,11 @@
 		max_sessions = 4096
 		tls {
 			certificate_file = ${certdir}/server.pem
-			private_key_password = {{EAP_PRIVATE_KEY_PASSWORD}}
+			private_key_password = `$ENV{EAP_PRIVATE_KEY_PASSWORD}`
 			private_key_file = ${certdir}/server.pem
 			dh_file = ${raddbdir}/certs/dh
 			random_file = /dev/random
-			check_crl = {{ENABLE_CRL}}
+			check_crl = `$ENV{ENABLE_CRL}`
 			ca_path = ${certdir}
 			cipher_list = "HIGH"
 			ecdh_curve = "secp384r1"
@@ -30,9 +30,9 @@
 			}
 
 			ocsp {
-				enable = {{ENABLE_OCSP}}
-				override_cert_url = {{OCSP_OVERRIDE_CERT_URL}}
-				url = "http://{{OCSP_URL}}"
+				enable = `$ENV{ENABLE_OCSP}`
+				override_cert_url = `$ENV{OCSP_OVERRIDE_CERT_URL}`
+				url = "http://`$ENV{OCSP_URL}`"
 			}
 
 			staple {

--- a/radius/sites-enabled/radsec
+++ b/radius/sites-enabled/radsec
@@ -8,7 +8,7 @@ server radsec {
     clients = radsec
 
     tls {
-      private_key_password = {{RADSEC_PRIVATE_KEY_PASSWORD}}
+      private_key_password = `$ENV{RADSEC_PRIVATE_KEY_PASSWORD}`
       private_key_file = ${radsec_certdir}/server.pem
       certificate_file = ${radsec_certdir}/server.pem
       fragment_size = 1024

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,28 +3,6 @@ set -eo pipefail
 
 prefix=/etc/freeradius/3.0
 
-configure_crl() {
-  sed -i "s/{{ENABLE_CRL}}/${ENABLE_CRL}/g" $prefix/mods-enabled/eap
-}
-
-configure_ocsp() {
-  sed -i "s/{{OCSP_URL}}/${OCSP_URL}/g" $prefix/mods-enabled/eap
-  sed -i "s/{{OCSP_OVERRIDE_CERT_URL}}/${OCSP_OVERRIDE_CERT_URL}/g" $prefix/mods-enabled/eap
-  sed -i "s/{{ENABLE_OCSP}}/${ENABLE_OCSP}/g" $prefix/mods-enabled/eap
-}
-
-inject_db_credentials() {
-  sed -i "s/{{DB_HOST}}/${DB_HOST}/g" $prefix/mods-config/python3/policyengine.py
-  sed -i "s/{{DB_USER}}/${DB_USER}/g" $prefix/mods-config/python3/policyengine.py
-  sed -i "s/{{DB_PASS}}/${DB_PASS}/g" $prefix/mods-config/python3/policyengine.py
-  sed -i "s/{{DB_NAME}}/${DB_NAME}/g" $prefix/mods-config/python3/policyengine.py
-}
-
-inject_certificate_parameters() {
-  sed -i "s/{{EAP_PRIVATE_KEY_PASSWORD}}/${EAP_PRIVATE_KEY_PASSWORD}/g" $prefix/mods-enabled/eap
-  sed -i "s/{{RADSEC_PRIVATE_KEY_PASSWORD}}/${RADSEC_PRIVATE_KEY_PASSWORD}/g" $prefix/sites-enabled/radsec
-}
- 
 fetch_certificates() {
     if [ "$LOCAL_DEVELOPMENT" == "true" ]; then
       cp -pr ./test/certs/* $prefix/certs
@@ -74,10 +52,6 @@ start_freeradius_server() {
 }
 
 main() {
-  configure_ocsp
-  inject_db_credentials
-  inject_certificate_parameters
-  configure_crl
   fetch_certificates
   fetch_authorised_macs
   fetch_authorised_clients


### PR DESCRIPTION
There is no need to inject static strings into the configuration,
FreeRadius and Python can read these dynamically.

https://github.com/FreeRADIUS/freeradius-server/blob/v3.0.x/raddb/radiusd.conf.in#L419