### PR TITLE
Refactor radiusd.conf

### DIFF
--- a/radius/radiusd.conf
+++ b/radius/radiusd.conf
@@ -11,7 +11,7 @@ confdir = ${raddbdir}
 modconfdir = ${confdir}/mods-config
 certdir = ${confdir}/certs
 radsec_certdir = ${certdir}/radsec
-cadir   = ${confdir}/certs
+cadir = ${confdir}/certs
 run_dir = ${localstatedir}/run/${name}
 db_dir = ${raddbdir}
 libdir = ${exec_prefix}/lib/freeradius
@@ -19,11 +19,16 @@ pidfile = ${run_dir}/${name}.pid
 correct_escapes = true
 max_request_time = 30
 cleanup_delay = 5
-# 1024 * 200 (200 sites with 1024 requests each)
 max_requests = 204800
 hostname_lookups = no
 checkrad = ${sbindir}/checkrad
-proxy_requests  = no
+proxy_requests = no
+
+log {
+  destination = stdout
+  colourise = no
+  auth = yes
+}
 
 thread pool {
 	start_servers = 5
@@ -31,14 +36,6 @@ thread pool {
 	min_spare_servers = 3
 	max_spare_servers = 10
 	max_requests_per_server = 0
-	auto_limit_acct = no
-}
-
-log {
-  destination = stdout
-  colourise = yes
-  file = ${logdir}/radius.log
-  auth = yes
 }
 
 security {
@@ -46,18 +43,15 @@ security {
   max_attributes = 200
   reject_delay = 1
   status_server = yes
-  allow_vulnerable_openssl = 'CVE-2016-6304' # The ocsp vulnerability does not affect us, as it's switched off.
 }
 
 modules {
   $INCLUDE mods-enabled/
 }
 
-instantiate { }
-
 policy {
   $INCLUDE policy.d/
 }
 
 $INCLUDE sites-enabled/
-$INCLUDE /etc/freeradius/3.0/clients.conf
+$INCLUDE ${raddbdir}/clients.conf


### PR DESCRIPTION
Fixed whitespace
Remove explicit entries that are the same as the defaults
Don't colourised output or define log file as we use STDOUT
Don't allow CVE which was targetted at older versions of Openssl
Remove unused empty module block