### PR TITLE
Audit and optimally configure eap module

### DIFF
--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -1,9 +1,7 @@
 eap eap {
   default_eap_type = ttls
-  timer_expire     = 60
-  ignore_unknown_eap_types = no
-  cisco_accounting_username_bug = no
-  max_sessions = 4096
+  ignore_unknown_eap_types = yes
+  max_sessions = ${max_requests}
 
   tls {
     certificate_file = ${certdir}/server.pem
@@ -14,16 +12,12 @@ eap eap {
     check_crl = `$ENV{ENABLE_CRL}`
     ca_path = ${certdir}
     cipher_list = "HIGH"
-    ecdh_curve = "secp384r1"
+    fragment_size = 1024
     tls_min_version = "1.2"
+    tls_max_version = "1.2"
     require_client_cert = yes
     auto_chain = no
-
-    cache {
-      enable = no
-      lifetime = 24
-      max_entries = 255
-    }
+    reject_unknown_intermediate_ca = yes
 
     verify {
       tmpdir = /tmp/radiusd


### PR DESCRIPTION
We want to ignore all unknown EAP types
Max sessions now inherits from max_requests
Set TLS max version to 1.2
Reject unknown intermediate CA certificates