### PR TITLE
Bump radsec timeout from 30s to 50s

### DIFF
--- a/radius/sites-enabled/radsec
+++ b/radius/sites-enabled/radsec
@@ -7,6 +7,10 @@ server radsec {
     proto = tcp
     clients = radsec
 
+    limit {
+      idle_timeout = 50
+    }
+
     tls {
       private_key_password = `$ENV{RADSEC_PRIVATE_KEY_PASSWORD}`
       private_key_file = ${radsec_certdir}/server.pem


### PR DESCRIPTION
We are seeing timeouts on the Aruba 2930F, FreeRadius closes the
connection after 30 seconds of inactivity. Increase this to see if the
Radsec tunnel remains up.