### PR TITLE
Change EAP to use input from tests rather than the full http here, it…

### DIFF
--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -27,7 +27,7 @@ eap eap {
     ocsp {
       enable = `$ENV{ENABLE_OCSP}`
       override_cert_url = `$ENV{OCSP_OVERRIDE_CERT_URL}`
-      url = "http://`$ENV{OCSP_URL}`"
+      url = `$ENV{OCSP_URL}`
     }
   }
 


### PR DESCRIPTION
… destroys the string and freeradius cannot parse it correctly