### PR TITLE
Use latest version of NGINX

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,5 @@
 ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/nginx:nginx-1-19-5-alpine
+FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/nginx:nginx-1-21-4-alpine
 
 EXPOSE 8000
 CMD ["/bin/sh", "-c", "sed -i 's/listen  .*/listen 8000;/g' /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"]


### PR DESCRIPTION
The current Alpine NGINX container that we use for NACS has outdated packages.
Use the latest version of the shared services base images to patch any
vulnerabilities.