### PR TITLE
Increase idle_timeout for RadSec connections

### DIFF
--- a/radius/sites-enabled/radsec
+++ b/radius/sites-enabled/radsec
@@ -8,7 +8,7 @@ server radsec {
     clients = radsec
 
     limit {
-      idle_timeout = 60
+      idle_timeout = 180
       lifetime = 0
     }
 


### PR DESCRIPTION
The Aruba 2930F only does server status checks every 2 minutes by
default. Allow a TCP connection to idle for 3 mintutes before it is
removed.