### PR TITLE
Pull base images directly from Dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/network-access-control-server:ubuntu-20-04
+FROM ubuntu:20.04
 ARG LOCAL_DEVELOPMENT=false
 ENV TZ=UTC
 ENV PYTHONUNBUFFERED=1

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,13 @@
-authenticate-docker: check-container-registry-account-id
+authenticate-docker:
 	./scripts/authenticate_docker.sh
 
-check-container-registry-account-id:
-	./scripts/check_container_registry_account_id.sh
-
-build: check-container-registry-account-id
-	docker build -t radius ./ --build-arg SHARED_SERVICES_ACCOUNT_ID
+build:
+	docker build -t radius ./
 
 build-nginx:
-	docker build -t nginx ./nginx --build-arg SHARED_SERVICES_ACCOUNT_ID
+	docker build -t nginx ./nginx
 
-deploy: 
+deploy:
 	./scripts/deploy.sh
 
 publish: build build-nginx
@@ -19,4 +16,4 @@ publish: build build-nginx
 publish-dictionaries:
 	./scripts/publish_dictionaries.sh
 
-.PHONY: build run publish deploy check-container-registry-account-id publish_dictionaires
+.PHONY: build run publish deploy publish_dictionaires

--- a/README.md
+++ b/README.md
@@ -17,17 +17,20 @@ This is the RADIUS Server for managing Network Access Control.
 
 ## Getting Started
 
-### Authenticating Docker with AWS ECR
+### Authenticating with DockerHub
 
-The Docker base image is stored in ECR. Prior to building the container you must authenticate Docker to the ECR registry. [Details can be found here](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth).
 
-If you have [aws-vault](https://github.com/99designs/aws-vault#installing) configured with credentials for shared services, do the following to authenticate:
+Local development shouldn't go over the download limits of Dockerhub.
+https://docs.docker.com/docker-hub/download-rate-limit/
 
-```bash
-aws-vault exec SHARED_SERVICES_VAULT_PROFILE_NAME -- aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin SHARED_SERVICES_ACCOUNT_ID.dkr.ecr.eu-west-2.amazonaws.com
+If these limits are encountered, authenticating with Docker is required:
+
 ```
+export DOCKER_USERNAME=your-docker-hub-username
+export DOCKER_PASSWORD=your-docker-hub-password
 
-Replace ```SHARED_SERVICES_VAULT_PROFILE_NAME``` and ```SHARED_SERVICES_ACCOUNT_ID``` in the command above with the profile name and ID of the shared services account configured in aws-vault.
+make authenticate-docker
+```
 
 ### Starting the App
 

--- a/buildspec.test.yml
+++ b/buildspec.test.yml
@@ -4,8 +4,8 @@ env:
   variables:
     AWS_REGION: eu-west-2
   parameter-store:
-    ROLE_ARN: /codebuild/pttp-ci-infrastructure-core-pipeline/development/assume_role # tests hardcoded to only run in development
-    SHARED_SERVICES_ACCOUNT_ID: /codebuild/staff_device_shared_services_account_id
+    DOCKER_USERNAME: "/moj-network-access-control/docker/username"
+    DOCKER_PASSWORD: "/moj-network-access-control/docker/password"
 
 phases:
   install:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,7 +8,8 @@ env:
     TARGET_AWS_ACCOUNT_ID: "/codebuild/$ENV/account_id"
     TERRAFORM_OUTPUTS: "/moj-network-access-control/terraform/$ENV/outputs"
     ROLE_ARN: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"
-    SHARED_SERVICES_ACCOUNT_ID: /codebuild/staff_device_shared_services_account_id
+    DOCKER_USERNAME: "/moj-network-access-control/docker/username"
+    DOCKER_PASSWORD: "/moj-network-access-control/docker/password"
 
 phases:
   build:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,4 @@
-ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/nginx:nginx-1-21-4-alpine
+FROM nginx:1.19.8-alpine
 
 EXPOSE 8000
 CMD ["/bin/sh", "-c", "sed -i 's/listen  .*/listen 8000;/g' /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"]

--- a/scripts/authenticate_docker.sh
+++ b/scripts/authenticate_docker.sh
@@ -2,4 +2,4 @@
 
 set -eu pipefail
 
-aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
+docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}

--- a/scripts/check_container_registry_account_id.sh
+++ b/scripts/check_container_registry_account_id.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-if [ -z ${SHARED_SERVICES_ACCOUNT_ID} ]; then
-  echo "Please set enviroment variable SHARED_SERVICES_ACCOUNT_ID for shared services";
-  exit 1;
-fi


### PR DESCRIPTION
The MoJ Docker organisation has acquired licenses, which means we
don't need to manage our own base images anymore.

Developers can authenticate locally (and shouldn't get rate limited),
and CI will authenticate with service credentials.