### PR TITLE
Invert MAB conditional

### DIFF
--- a/radius/sites-enabled/default
+++ b/radius/sites-enabled/default
@@ -16,18 +16,14 @@ server default {
     rewrite_calling_station_id
     authorized_macs
 
-    if (!EAP-Message) {
-
-      if (!ok) {
-        reject
-      }
-      else {
-        update control {
-          Auth-Type := Accept
-        }
+    if (EAP-Message) {
+      eap
+    } elsif (!EAP-Message && ok) {
+      update control {
+        Auth-Type := Accept
       }
     } else {
-      eap
+      reject
     }
   }
 


### PR DESCRIPTION
Currently it allows any mac onto the network even though the entry
isn't in the authorised macs file. By looking for EAP first, we can
fix this issue and allow EAP and non-EAP to exist together.