### PR TITLE
Always boot FreeRadius with verbose logging on

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -35,11 +35,7 @@ start_packet_capture() {
 start_freeradius_server() {
   export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libpython3.8.so"
 
-  if [ "$VERBOSE_LOGGING" == "true" ]; then
-    freeradius -fxx -l stdout
-  else
-    freeradius -f -l stdout
-  fi
+  freeradius -fxx -l stdout
 }
 
 main() {


### PR DESCRIPTION
Remove the conditional to allow booting the server with minimal logs.
There is a dependency on some of the log information to populate metrics
in the monitoring and alerting platform.