### PR TITLE
Fix broken anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the RADIUS Server for managing Network Access Control.
 ## Table of Contents
 
 - [Getting Started](#getting-started)
-  - [Authenticating Docker with AWS ECR](#authenticating-docker-with-aws-ecr)
+  - [Authenticating with DockerHub](#authenticating-with-dockerhub)
   - [Starting the App](#starting-the-app)
   - [Deployment](#deployment)
     - [Targetting the ECS Cluster and Service to Deploy](#targetting-the-ecs-cluster-and-service-to-deploy)


### PR DESCRIPTION
This wasn't updated when we stopped using ECR to cache images.
Link to authenticating with DockerHub instead.