### PR TITLE
Disable OCSP Nonce

### DIFF
--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -27,6 +27,7 @@ eap eap {
       enable = `$ENV{ENABLE_OCSP}`
       override_cert_url = `$ENV{OCSP_OVERRIDE_CERT_URL}`
       url = `$ENV{OCSP_URL}`
+      use_nonce = no
     }
   }
 


### PR DESCRIPTION
When this is enabled, the ocsp requests fail with "unauthorized".
Disable this to allow quering OCSP for Dom1 devices.