### PR TITLE
Ability to force an Access-Reject from Policy Engine

### DIFF
--- a/radius/mods-config/python3/policyengine.py
+++ b/radius/mods-config/python3/policyengine.py
@@ -46,14 +46,16 @@ def post_auth(p):
             reply_list = fallback_policy_responses(cursor, payload_dict['Client-Shortname'])
 
         print(payload_dict.get('Client-Shortname'), "POLICY ENGINE: Policy Response -", tuple(reply_list))
-        update_dict = {
-            "reply" : (
-                reply_list
-            )
-        }
-            
+
+        reply_payload = { "reply" : (reply_list) }
+        result = radiusd.RLM_MODULE_OK
+
+        for key, value in reply_list:
+            if key == "Post-Auth-Type" and value == "Reject":
+                result = radiusd.RLM_MODULE_FAIL
+
         connection.close()
-        return radiusd.RLM_MODULE_OK, update_dict
+        return result, reply_payload
 
 def grouped_rules_by_policy(cursor, _site):
     rules_sql = "SELECT `policies`.`id` policy_id, `policies`.`name` policy_name, `request_attribute`, `operator`, `value`, `policies`.`rule_count` " \


### PR DESCRIPTION
By returning RLM_MODULE_FAIL instead of RLM_MODULE_OK, we are able to
short curcuit the authentication at the post-auth stage.

This looks for a response of "Post-Auth-Type == Reject", which will send
back an Access-Reject even though the authenticate stage resulted in
Access-Accept. This is a better user experience than sending devices to
a blackhole VLAN.