### PR TITLE
Remove limits on TCP connections for Radsec

### DIFF
--- a/radius/sites-enabled/default
+++ b/radius/sites-enabled/default
@@ -5,7 +5,7 @@ server default {
     port = 1812
 
     limit {
-      max_connections = 64
+      max_connections = 0
       lifetime = 10
       idle_timeout = 30
     }

--- a/radius/sites-enabled/radsec
+++ b/radius/sites-enabled/radsec
@@ -10,6 +10,7 @@ server radsec {
     limit {
       idle_timeout = 180
       lifetime = 0
+      max_connections = 0
     }
 
     tls {
@@ -30,8 +31,6 @@ server radsec {
 
       cache {
             enable = no
-            lifetime = 24
-            max_entries = 255
       }
     }
   }


### PR DESCRIPTION
We do not want to limit the amount of concurrent connections