### PR TITLE
Upgrade to FreeRadius 3.2.0LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ ENV LOCAL_DEVELOPMENT=$LOCAL_DEVELOPMENT
 RUN apk --update --no-cache add \
   git openssl~=1.1.1n jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
 
-RUN git clone https://github.com/FreeRADIUS/freeradius-server.git \
-    && cd freeradius-server \
-    && git checkout dc11c2baae78a0f292ba377cfe25ea0d67d60e6a \
-    && ./configure --build=x86_64-unknown-linux-gnu \
+RUN wget https://github.com/FreeRADIUS/freeradius-server/archive/release_3_2_0.tar.gz \
+    && tar xzvf release_3_2_0.tar.gz \
+    && cd freeradius-server-release_3_2_0 \
+    && ./configure --with-experimental-modules --with-rlm-python3-bin=/usr/bin/python --build=x86_64-unknown-linux-gnu \
     && make \
     && make install \
     && mkdir -p /tmp/radiusd /usr/local/etc/raddb /usr/local/etc/raddb/certs \

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -40,8 +40,6 @@ start_packet_capture() {
 }
 
 start_freeradius_server() {
-  export LD_PRELOAD="usr/lib/python3.8/config-3.8-x86_64-linux-gnu/libpython3.8.so"
-
   /usr/local/sbin/radiusd -fxx -l stdout
 }
 


### PR DESCRIPTION
This LTS version was recently published and is compatible with 3.0
configurations.

https://freeradius.org/release_notes/?br=3.2.x&re=3.2.0

There is no package for this version in Alpine yet, when it becomes
available we can install it and not have to compile from source.

The experimental modules flag is required to install python
dependencies.