### PR TITLE
Bump Openssl version, a new CVE was discovered

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHONUNBUFFERED=1
 ENV LOCAL_DEVELOPMENT=$LOCAL_DEVELOPMENT
 
 RUN apk --update --no-cache add \
-  git openssl~=1.1.1n jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
+  git openssl~=1.1.1o jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
 
 RUN wget https://github.com/FreeRADIUS/freeradius-server/archive/release_3_2_0.tar.gz \
     && tar xzvf release_3_2_0.tar.gz \


### PR DESCRIPTION
https://www.openssl.org/news/vulnerabilities.html#CVE-2022-1292