### PR TITLE
Sleep before reporting health

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -21,8 +21,8 @@ fetch_authorised_macs() {
 
 report_container_health() {
   while true; do
-    echo "Health Check: OK"
     sleep 60
+    echo "Health Check: OK"
   done
 }
 


### PR DESCRIPTION
To make this metric more accurate, you want freeradius to be running for
a while before reporting health.

Currently an unhealthy host can report as healthy just before it's
removed from the target group