### PR TITLE
Reduce post-auth duplication in virtual servers

### DIFF
--- a/radius/policy.d/invoke_policy_engine
+++ b/radius/policy.d/invoke_policy_engine
@@ -1,0 +1,8 @@
+invoke_policy_engine {
+  update request {
+    TLS-Client-Cert-Subject-Alt-Name-Dns += "%{request:TLS-Client-Cert-Subject-Alt-Name-Dns[*]}"
+    Client-Shortname := "%{Client-Shortname}"
+  }
+
+  python3
+}

--- a/radius/sites-enabled/default
+++ b/radius/sites-enabled/default
@@ -32,11 +32,6 @@ server default {
   }
 
   post-auth {
-    update request {
-      TLS-Client-Cert-Subject-Alt-Name-Dns += "%{request:TLS-Client-Cert-Subject-Alt-Name-Dns[*]}"
-      Client-Shortname := "%{Client-Shortname}"
-    }
-
-    python3
+    invoke_policy_engine
   }
 }

--- a/radius/sites-enabled/radsec
+++ b/radius/sites-enabled/radsec
@@ -1,4 +1,3 @@
-
 server radsec {
   listen {
     type = auth
@@ -60,11 +59,6 @@ server radsec {
   }
 
   post-auth {
-    update request {
-      TLS-Client-Cert-Subject-Alt-Name-Dns += "%{request:TLS-Client-Cert-Subject-Alt-Name-Dns[*]}"
-      Client-Shortname := "%{Client-Shortname}"
-    }
-
-    python3
+    invoke_policy_engine
   }
 }


### PR DESCRIPTION
Create a new policy / function which can be called from both radsec and
default virtual servers