### PR TITLE
:wrench: Upgrade `openssl~=1.1.1q` to `openssl~=1.1.1s-r1`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHONUNBUFFERED=1
 ENV LOCAL_DEVELOPMENT=$LOCAL_DEVELOPMENT
 
 RUN apk --update --no-cache add \
-  git openssl~=1.1.1q jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
+  git openssl~=1.1.1s-r1 jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
 
 RUN wget https://github.com/FreeRADIUS/freeradius-server/archive/release_3_2_0.tar.gz \
     && tar xzvf release_3_2_0.tar.gz \


### PR DESCRIPTION
Upgrade from `openssl~=1.1.1q` to `openssl~=1.1.1s-r1`.

This change upgrades the versions of `openssl`, we are required to do this due to [this](https://github.com/ministryofjustice/network-access-control-server/issues/147) Issue but would have had to do this at some point soon regardless. 

Release notes are [here](https://www.openssl.org/news/openssl-1.1.1-notes.html) and give any cause for concern. 