### PR TITLE
Openssl upgrade fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.16.4
+FROM alpine:3.17
 ARG LOCAL_DEVELOPMENT=false
 ENV PYTHONUNBUFFERED=1
 ENV LOCAL_DEVELOPMENT=$LOCAL_DEVELOPMENT
 
 RUN apk --update --no-cache add \
-  git openssl~=1.1.1u-r2 jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
+  git openssl~=3.0.10-r0 jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
 RUN wget https://github.com/FreeRADIUS/freeradius-server/archive/release_3_2_2.tar.gz \
   && tar xzvf release_3_2_2.tar.gz \
   && cd freeradius-server-release_3_2_2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,25 @@
-FROM alpine:3.17
+FROM alpine:3.18
 ARG LOCAL_DEVELOPMENT=false
 ENV PYTHONUNBUFFERED=1
 ENV LOCAL_DEVELOPMENT=$LOCAL_DEVELOPMENT
+ENV FREE_RADIUS_VERSION="3_2_2"
 
 RUN apk --update --no-cache add \
-  git openssl~=3.0.10-r0 jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
-RUN wget https://github.com/FreeRADIUS/freeradius-server/archive/release_3_2_2.tar.gz \
-  && tar xzvf release_3_2_2.tar.gz \
-  && cd freeradius-server-release_3_2_2 \
+  git openssl~=3.1.3-r0 jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
+
+RUN wget https://github.com/FreeRADIUS/freeradius-server/archive/release_$FREE_RADIUS_VERSION.tar.gz \
+  && tar xzvf release_$FREE_RADIUS_VERSION.tar.gz \
+  && cd freeradius-server-release_$FREE_RADIUS_VERSION \
   && ./configure --with-experimental-modules --with-rlm-python3-bin=/usr/bin/python --build=x86_64-unknown-linux-gnu \
   && make \
   && make install \
   && mkdir -p /tmp/radiusd /usr/local/etc/raddb /usr/local/etc/raddb/certs \
   && rm -fr /usr/local/etc/raddb/sites-enabled/* \
   && openssl dhparam -out /usr/local/etc/raddb/dh 1024 && ln -sf python3 /usr/bin/python \
-  && pip3 install --ignore-installed --no-cache --upgrade pip six setuptools py-radius PyMySQL \
+  && openssl dhparam -out /usr/local/etc/raddb/dh 1024 && ln -sf python3 /usr/bin/python \
+  && pip3 install --ignore-installed --no-cache --upgrade wheel setuptools pip --upgrade \
+  && pip3 install --ignore-installed --no-cache --upgrade  six \
+  && pip3 install --ignore-installed --no-cache --upgrade py-radius PyMySQL \
   && cd - \
   && rm -fr ./freeradius-server \
   && chown root:root /usr/bin/dumpcap

--- a/docs/PackageVersions.md
+++ b/docs/PackageVersions.md
@@ -41,7 +41,7 @@ zlib-1.2.12-r1
 linux-headers-5.10.41-r0
 py3-parsing-2.4.7-r2
 mpdecimal-2.5.1-r1
-openssl-dev-1.1.1n-r0
+openssl-dev-3.0.10-r0
 gnutls-3.7.1-r0
 py3-colorama-0.4.4-r1
 py3-requests-2.26.0-r1
@@ -109,7 +109,7 @@ py3-progress-1.6-r0
 py3-packaging-20.9-r1
 py3-tomli-1.2.2-r0
 wireshark-common-3.4.13-r0
-openssl-1.1.1n-r0
+openssl-3.0.10-r0
 py3-certifi-2020.12.5-r1
 libcrypto1.1-1.1.1n-r0
 libressl3.4-libcrypto-3.4.3-r0

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.19.8-alpine
+FROM nginx:1.25-alpine
 
 EXPOSE 8000
 CMD ["/bin/sh", "-c", "sed -i 's/listen  .*/listen 8000;/g' /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"]

--- a/scripts/install_aws_sdk.sh
+++ b/scripts/install_aws_sdk.sh
@@ -2,10 +2,7 @@
 
 set -e
 
-if ! [ $1 == "true" ]; then
-  wget "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" \
-  && unzip awscli-bundle.zip \
-  && rm awscli-bundle.zip \
-  && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws \
-  && rm -r ./awscli-bundle
+if [ "$1" != "true" ]; then
+apk add --no-cache aws-cli
 fi
+


### PR DESCRIPTION
These changes upgrade the Alpine versions to higher than 3.16 as from 3.17 onwards OpenSSL v3 was installed.