### PR TITLE
updating openssl packge name for alpine 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV LOCAL_DEVELOPMENT=$LOCAL_DEVELOPMENT
 ENV FREE_RADIUS_VERSION="3_2_2"
 
 RUN apk --update --no-cache add \
-  git openssl~=3.1.4-r0 jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
+  git openssl~=3.1.4-r1 jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
 
 RUN wget https://github.com/FreeRADIUS/freeradius-server/archive/release_$FREE_RADIUS_VERSION.tar.gz \
   && tar xzvf release_$FREE_RADIUS_VERSION.tar.gz \


### PR DESCRIPTION
Openssl package changed in alpine 3.18 and causing build failure 