### PR TITLE
Added dual platform build to the docker build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ authenticate-docker:
 	./scripts/authenticate_docker.sh
 
 build:
-	docker build -t radius ./
+	docker build --platform=linux/amd64,linux/arm64 -t radius ./
 
 build-nginx:
-	docker build -t nginx ./nginx
+	docker build --platform=linux/amd64,linux/arm64-t nginx ./nginx
 
 deploy:
 	./scripts/deploy.sh


### PR DESCRIPTION
This is to cover both intel and arm chipset (found in M1 or M* Apple MacBook and later AWS Graphon).

This needs a configuration change in the Docker Desktop settings. Enable the check box for the "Use containerd for pulling and storing images." option and restart Docker Desktop.

Jira: ND-65