### PR TITLE
ND-463 Revert main branch - Added new env var and OpenSSL version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ ENV PYTHONUNBUFFERED=1
 ENV LOCAL_DEVELOPMENT=$LOCAL_DEVELOPMENT
 ENV FREE_RADIUS_VERSION="3_2_2"
 
+ENV OPENSSL_VERSION="3.1.6-r0"
+
 RUN apk --update --no-cache add \
-  git openssl~=3.1.4-r6 jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
+  git openssl~=${OPENSSL_VERSION} jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers
 
 RUN wget https://github.com/FreeRADIUS/freeradius-server/archive/release_$FREE_RADIUS_VERSION.tar.gz \
   && tar xzvf release_$FREE_RADIUS_VERSION.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHONUNBUFFERED=1
 ENV LOCAL_DEVELOPMENT=$LOCAL_DEVELOPMENT
 ENV FREE_RADIUS_VERSION="3_2_2"
 
-ENV OPENSSL_VERSION="3.1.6-r0"
+ENV OPENSSL_VERSION="3.1.6"
 
 RUN apk --update --no-cache add \
   git openssl~=${OPENSSL_VERSION} jq tshark python3-dev py3-pip bash make curl gcc make g++ zlib-dev talloc-dev libressl openssl-dev linux-headers


### PR DESCRIPTION
Required as the definded veresion no linger exists, this is a common problem as the "-rc" version is specified. So we can update the variable as and when required to prevent errro messages ad the one below. 2.201 ERROR: unable to select packages:
2.207   openssl-3.1.6-r0:
2.207     breaks: world[openssl~3.1.4-r6]

ND-463