### PR TITLE
Do not tag the radius image during build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ authenticate-docker: ## ## Authenticate docker script
 
 .PHONY: build
 build: ## Docker build Radius server
-	docker build --platform=linux/amd64 -t radius ./
+	docker build --platform=linux/amd64 --provenance=false -t radius ./
 
 .PHONY: build-nginx
 build-nginx: ## Docker build nginx


### PR DESCRIPTION
This required the publish script to have a refactor which we will do at a later time.

ND-463