### PR TITLE
Reduce server log level

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -100,7 +100,7 @@ check_cert_expiry() {
 }
 
 start_freeradius_server() {
-  /usr/local/sbin/radiusd -fxxx -l stdout
+  /usr/local/sbin/radiusd -fxx -l stdout
 }
 
 main() {


### PR DESCRIPTION
log level was increased for debugging. Hwever in production it's creating a lot of noise and the metrics are causing an alert in which every mention of error is triggering a high error count.

ND-463